### PR TITLE
Persist favorited events

### DIFF
--- a/.idea/assetWizardSettings.xml
+++ b/.idea/assetWizardSettings.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="WizardSettings">
+    <option name="children">
+      <map>
+        <entry key="imageWizard">
+          <value>
+            <PersistentState />
+          </value>
+        </entry>
+        <entry key="vectorWizard">
+          <value>
+            <PersistentState>
+              <option name="children">
+                <map>
+                  <entry key="vectorAssetStep">
+                    <value>
+                      <PersistentState>
+                        <option name="children">
+                          <map>
+                            <entry key="clipartAsset">
+                              <value>
+                                <PersistentState>
+                                  <option name="values">
+                                    <map>
+                                      <entry key="url" value="jar:file:/Applications/Android%20Studio.app/Contents/plugins/android/lib/android.jar!/images/material_design_icons/toggle/ic_star_black_24dp.xml" />
+                                    </map>
+                                  </option>
+                                </PersistentState>
+                              </value>
+                            </entry>
+                          </map>
+                        </option>
+                        <option name="values">
+                          <map>
+                            <entry key="color" value="1f84a5" />
+                            <entry key="outputName" value="ic_full_star" />
+                            <entry key="sourceFile" value="$USER_HOME$" />
+                          </map>
+                        </option>
+                      </PersistentState>
+                    </value>
+                  </entry>
+                </map>
+              </option>
+            </PersistentState>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/app/src/main/java/org/hackillinois/android/model/Event.kt
+++ b/app/src/main/java/org/hackillinois/android/model/Event.kt
@@ -49,8 +49,8 @@ data class Event(
         }
     }
 
-    private val MILLIS_IN_SECONDS = 1000
-
     fun getStart(): Calendar = Calendar.getInstance().apply { timeInMillis = startTime * MILLIS_IN_SECONDS }
     fun getEnd(): Calendar = Calendar.getInstance().apply { timeInMillis = endTime * MILLIS_IN_SECONDS }
 }
+
+private const val MILLIS_IN_SECONDS = 1000L

--- a/app/src/main/java/org/hackillinois/android/utils/FavoritesManager.java
+++ b/app/src/main/java/org/hackillinois/android/utils/FavoritesManager.java
@@ -1,0 +1,36 @@
+package org.hackillinois.android.utils;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import org.hackillinois.android.R;
+import org.hackillinois.android.model.Event;
+
+public class FavoritesManager {
+
+    public static void favoriteEvent(Context context, Event event) {
+        setBoolean(context, event.getName(), true);
+    }
+
+    public static void unfavoriteEvent(Context context, Event event) {
+        setBoolean(context, event.getName(), false);
+    }
+
+    public static boolean isFavorited(Context context, Event event) {
+        return getBoolean(context, event.getName(), false);
+    }
+
+    private static void setBoolean(Context context, String key, boolean value) {
+        SharedPreferences.Editor editor = getFavoritesPrefs(context).edit();
+        editor.putBoolean(key, value);
+        editor.apply();
+    }
+
+    private static boolean getBoolean(Context context, String key, boolean defValue) {
+        return getFavoritesPrefs(context).getBoolean(key, defValue);
+    }
+
+    private static SharedPreferences getFavoritesPrefs(Context context) {
+        return context.getSharedPreferences(context.getString(R.string.favorites_pref_file_key), Context.MODE_PRIVATE);
+    }
+}

--- a/app/src/main/java/org/hackillinois/android/utils/FavoritesManager.java
+++ b/app/src/main/java/org/hackillinois/android/utils/FavoritesManager.java
@@ -17,7 +17,7 @@ public class FavoritesManager {
     }
 
     public static boolean isFavorited(Context context, Event event) {
-        return getBoolean(context, event.getName(), false);
+        return getBoolean(context, event.getName());
     }
 
     private static void setBoolean(Context context, String key, boolean value) {
@@ -26,8 +26,8 @@ public class FavoritesManager {
         editor.apply();
     }
 
-    private static boolean getBoolean(Context context, String key, boolean defValue) {
-        return getFavoritesPrefs(context).getBoolean(key, defValue);
+    private static boolean getBoolean(Context context, String key) {
+        return getFavoritesPrefs(context).getBoolean(key, false);
     }
 
     private static SharedPreferences getFavoritesPrefs(Context context) {

--- a/app/src/main/java/org/hackillinois/android/view/EventInfoActivity.kt
+++ b/app/src/main/java/org/hackillinois/android/view/EventInfoActivity.kt
@@ -1,5 +1,7 @@
 package org.hackillinois.android.view
 
+import android.arch.lifecycle.Observer
+import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import kotlinx.android.synthetic.main.activity_event_info.*
@@ -7,14 +9,18 @@ import org.hackillinois.android.R
 import org.hackillinois.android.model.Event
 import android.content.Intent
 import android.net.Uri
+import org.hackillinois.android.viewmodel.EventInfoViewModel
 
 class EventInfoActivity : AppCompatActivity() {
+
+    private lateinit var viewModel: EventInfoViewModel
+    private lateinit var event: Event
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_event_info)
 
-        val event = intent?.extras?.get("event") as Event
+        event = intent?.extras?.get("event") as Event
 
         eventTitle.text = event.name
         eventLocation.text = event.locationDescription
@@ -24,6 +30,24 @@ class EventInfoActivity : AppCompatActivity() {
             val geoUri = "http://maps.google.com/maps?q=loc:${event.latitude},${event.longitude} (${event.locationDescription})"
             val intent = Intent(Intent.ACTION_VIEW, Uri.parse(geoUri))
             startActivity(intent)
+        }
+
+        favoriteEventImageView.setOnClickListener {
+            viewModel.changeFavoritedState(event)
+        }
+
+        viewModel = ViewModelProviders.of(this).get(EventInfoViewModel::class.java)
+        viewModel.isFavorited.observe(this, Observer { updateFavoritedUi(it) })
+        viewModel.getIsFavorited(event)
+    }
+
+    private fun updateFavoritedUi(isFavorited: Boolean?) {
+        isFavorited?.let {
+            if (isFavorited) {
+                favoriteEventImageView.setImageResource(R.drawable.ic_full_star)
+            } else {
+                favoriteEventImageView.setImageResource(R.drawable.ic_hollow_star)
+            }
         }
     }
 }

--- a/app/src/main/java/org/hackillinois/android/viewmodel/EventInfoViewModel.kt
+++ b/app/src/main/java/org/hackillinois/android/viewmodel/EventInfoViewModel.kt
@@ -1,0 +1,28 @@
+package org.hackillinois.android.viewmodel
+
+import android.app.Application
+import android.arch.lifecycle.AndroidViewModel
+import android.arch.lifecycle.MutableLiveData
+import org.hackillinois.android.model.Event
+import org.hackillinois.android.utils.FavoritesManager
+
+class EventInfoViewModel(val app: Application): AndroidViewModel(app) {
+    val isFavorited = MutableLiveData<Boolean>()
+    var localIsFavorited = false
+
+    fun getIsFavorited(event: Event) {
+        localIsFavorited = FavoritesManager.isFavorited(app.applicationContext, event)
+        isFavorited.postValue(localIsFavorited)
+    }
+
+    fun changeFavoritedState(event: Event) {
+        if (localIsFavorited) {
+            FavoritesManager.unfavoriteEvent(app.applicationContext, event)
+        } else {
+            FavoritesManager.favoriteEvent(app.applicationContext, event)
+        }
+        localIsFavorited = !localIsFavorited
+        isFavorited.postValue(localIsFavorited)
+    }
+
+}

--- a/app/src/main/res/drawable/ic_full_star.xml
+++ b/app/src/main/res/drawable/ic_full_star.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#1F84A5"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_hollow_star.xml
+++ b/app/src/main/res/drawable/ic_hollow_star.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#1F84A5"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M22,9.24l-7.19,-0.62L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21 12,17.27 18.18,21l-1.63,-7.03L22,9.24zM12,15.4l-3.76,2.27 1,-4.28 -3.32,-2.88 4.38,-0.38L12,6.1l1.71,4.04 4.38,0.38 -3.32,2.88 1,4.28L12,15.4z"/>
+</vector>

--- a/app/src/main/res/layout/activity_event_info.xml
+++ b/app/src/main/res/layout/activity_event_info.xml
@@ -61,4 +61,15 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
+
+    <ImageView
+        android:id="@+id/favoriteEventImageView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="24dp"
+        android:layout_marginRight="24dp"
+        android:layout_marginTop="24dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_hollow_star" />
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,4 +20,6 @@
     <string name="profile_emergency_contact_text">EMERGENCY CONTACT</string>
 
     <string name="event_info_directions_text">GET DIRECTIONS</string>
+
+    <string name="favorites_pref_file_key">org.hackillinois.android.favorites</string>
 </resources>


### PR DESCRIPTION
- Adds a favorite star to the events info activity (can be changed to an alarm too)
- Adds persistence of favorited events for the user
- For using the persistence elsewhere, user the `FavoritesManager` methods to save and determine if an event is favorited
- Closes #12 