### PR TITLE
Reschedule alarms when device boots

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 
     <application
         android:name=".App"
@@ -15,6 +16,12 @@
         android:theme="@style/AppTheme">
 
         <receiver android:name=".common.NotificationReceiver" />
+        <receiver android:name=".common.BootReceiver"
+            android:enabled="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED"></action>
+            </intent-filter>
+        </receiver>
 
         <activity
             android:name=".view.SplashScreenActivity"

--- a/app/src/main/java/org/hackillinois/android/common/BootReceiver.kt
+++ b/app/src/main/java/org/hackillinois/android/common/BootReceiver.kt
@@ -1,0 +1,20 @@
+package org.hackillinois.android.common
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import org.hackillinois.android.App
+import kotlin.concurrent.thread
+
+class BootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        thread {
+            val events = App.getDatabase().eventDao().getAllEventsList()
+            events.filter {
+                FavoritesManager.isFavorited(context, it.name)
+            }.forEach {
+                HackIllinoisNotificationManager.scheduleEventNotification(context, it)
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/hackillinois/android/common/HackIllinoisNotificationManager.java
+++ b/app/src/main/java/org/hackillinois/android/common/HackIllinoisNotificationManager.java
@@ -30,7 +30,7 @@ public class HackIllinoisNotificationManager {
         long timeToTrigger = event.getStartTimeMs() - MINUTES_BEFORE_TO_NOTIFY * MILLIS_IN_MINUTE;
 
         // don't set an alarm for an event that has already occurred
-        if (timeToTrigger < Calendar.getInstance().getTimeInMillis()) { return; }
+        if (event.getStartTimeMs() < Calendar.getInstance().getTimeInMillis()) { return; }
         alarmManager.set(AlarmManager.RTC_WAKEUP, timeToTrigger, alarmIntent);
     }
 

--- a/app/src/main/java/org/hackillinois/android/database/dao/EventDao.kt
+++ b/app/src/main/java/org/hackillinois/android/database/dao/EventDao.kt
@@ -10,6 +10,9 @@ interface EventDao {
     @Query("SELECT * FROM events")
     fun getAllEvents(): LiveData<List<Event>>
 
+    @Query("SELECT * FROM events")
+    fun getAllEventsList(): List<Event>
+
     @Query("SELECT * FROM events WHERE name LIKE :name LIMIT 1")
     fun getEvent(name: String): LiveData<Event>
 


### PR DESCRIPTION
Closes #38 

When the device boots, this code is run to reschedule alarms to trigger notifications for user-favorited events. I've verified that this works by restarting and still receiving a notification.