### PR TITLE
Centralize JWT management utility functions

### DIFF
--- a/app/src/main/java/org/hackillinois/android/common/JWTUtilities.kt
+++ b/app/src/main/java/org/hackillinois/android/common/JWTUtilities.kt
@@ -1,0 +1,32 @@
+package org.hackillinois.android.common
+
+import android.content.Context
+import android.content.SharedPreferences
+import org.hackillinois.android.R
+
+object JWTUtilities {
+    const val DEFAULT_JWT = ""
+    const val JWT_PREF_KEY = "jwt"
+
+    fun readJWT(context: Context): String {
+        val sharedPreferences = getSharedPreferences(context)
+        return sharedPreferences.getString(JWT_PREF_KEY, DEFAULT_JWT) ?: DEFAULT_JWT
+    }
+
+    fun writeJWT(context: Context, jwt: String) {
+        val editor = getSharedPreferences(context).edit()
+        editor.putString("jwt", jwt)
+        editor.apply()
+    }
+
+    fun clearJWT(context: Context) {
+        val editor = getSharedPreferences(context).edit()
+        editor.putString("jwt", DEFAULT_JWT)
+        editor.apply()
+    }
+
+    private fun getSharedPreferences(context: Context): SharedPreferences {
+        val prefKey = context.applicationContext.getString(R.string.authorization_pref_file_key)
+        return context.getSharedPreferences(prefKey, Context.MODE_PRIVATE)
+    }
+}

--- a/app/src/main/java/org/hackillinois/android/common/JWTUtilities.kt
+++ b/app/src/main/java/org/hackillinois/android/common/JWTUtilities.kt
@@ -20,9 +20,7 @@ object JWTUtilities {
     }
 
     fun clearJWT(context: Context) {
-        val editor = getSharedPreferences(context).edit()
-        editor.putString("jwt", DEFAULT_JWT)
-        editor.apply()
+        writeJWT(context, DEFAULT_JWT)
     }
 
     private fun getSharedPreferences(context: Context): SharedPreferences {

--- a/app/src/main/java/org/hackillinois/android/view/LoginActivity.kt
+++ b/app/src/main/java/org/hackillinois/android/view/LoginActivity.kt
@@ -10,6 +10,7 @@ import android.util.Log
 import kotlinx.android.synthetic.main.activity_login.*
 import org.hackillinois.android.App
 import org.hackillinois.android.R
+import org.hackillinois.android.common.JWTUtilities
 import org.hackillinois.android.model.auth.Code
 import org.hackillinois.android.model.auth.JWT
 import retrofit2.Call
@@ -69,7 +70,7 @@ class LoginActivity : AppCompatActivity() {
                             Log.e("LoginActivity", "Notifications update timed out!")
                         }
                     }
-                    storeJWT(it)
+                    JWTUtilities.writeJWT(applicationContext, it)
                     runOnUiThread {
                         launchMainActivity()
                     }
@@ -100,11 +101,5 @@ class LoginActivity : AppCompatActivity() {
     fun getOAuthProvider(): String {
         return applicationContext.getSharedPreferences(applicationContext.getString(R.string.authorization_pref_file_key), Context.MODE_PRIVATE).getString("provider", "")
                 ?: ""
-    }
-
-    fun storeJWT(jwt: String) {
-        val editor = applicationContext.getSharedPreferences(applicationContext.getString(R.string.authorization_pref_file_key), Context.MODE_PRIVATE).edit()
-        editor.putString("jwt", jwt)
-        editor.apply()
     }
 }

--- a/app/src/main/java/org/hackillinois/android/view/MainActivity.kt
+++ b/app/src/main/java/org/hackillinois/android/view/MainActivity.kt
@@ -19,6 +19,7 @@ import kotlinx.android.synthetic.main.layout_qr_sheet.*
 import kotlinx.android.synthetic.main.layout_qr_sheet.view.*
 import org.hackillinois.android.App
 import org.hackillinois.android.R
+import org.hackillinois.android.common.JWTUtilities
 import org.hackillinois.android.common.QRUtilities
 import org.hackillinois.android.database.entity.Attendee
 import org.hackillinois.android.database.entity.QR
@@ -165,7 +166,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun logout() {
-        clearJWT()
+        JWTUtilities.clearJWT(applicationContext)
 
         thread {
             App.database.clearAllTables()
@@ -177,12 +178,5 @@ class MainActivity : AppCompatActivity() {
                 finish()
             }
         }
-    }
-
-    private fun clearJWT() {
-        val jwtKey = this.getString(R.string.authorization_pref_file_key)
-        val editor = this.getSharedPreferences(jwtKey, Context.MODE_PRIVATE).edit()
-        editor.putString("jwt", defaultToken)
-        editor.apply()
     }
 }

--- a/app/src/main/java/org/hackillinois/android/view/SplashScreenActivity.kt
+++ b/app/src/main/java/org/hackillinois/android/view/SplashScreenActivity.kt
@@ -1,12 +1,11 @@
 package org.hackillinois.android.view
 
-import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import android.util.Log
 import org.hackillinois.android.App
-import org.hackillinois.android.R
+import org.hackillinois.android.common.JWTUtilities
 import org.hackillinois.android.database.entity.User
 import retrofit2.Call
 import retrofit2.Callback
@@ -16,14 +15,12 @@ import kotlin.concurrent.thread
 
 class SplashScreenActivity : AppCompatActivity() {
 
-    private val defaultJWT: String = ""
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val jwt = loadJWT()
+        val jwt = JWTUtilities.readJWT(applicationContext)
 
-        if (jwt != defaultJWT) {
+        if (jwt != JWTUtilities.DEFAULT_JWT) {
             val api = App.getAPI(jwt)
             api.user().enqueue(object : Callback<User> {
                 override fun onFailure(call: Call<User>, t: Throwable) {
@@ -67,10 +64,5 @@ class SplashScreenActivity : AppCompatActivity() {
         val mainIntent = Intent(this, LoginActivity::class.java)
         startActivity(mainIntent)
         finish()
-    }
-
-    fun loadJWT(): String {
-        return applicationContext.getSharedPreferences(applicationContext.getString(R.string.authorization_pref_file_key), Context.MODE_PRIVATE).getString("jwt", defaultJWT)
-                ?: defaultJWT
     }
 }


### PR DESCRIPTION
JWT management utilities were scattered across three different files, so they've now been centralized. Closes #183 