### PR TITLE
Fix jwt leak when logging in/out

### DIFF
--- a/app/src/main/java/org/hackillinois/android/repository/GenericRepository.kt
+++ b/app/src/main/java/org/hackillinois/android/repository/GenericRepository.kt
@@ -7,7 +7,7 @@ import retrofit2.Response
 import kotlin.concurrent.thread
 
 class GenericRepository<T>(
-    private val apiCall: Call<T>,
+    private val apiCallCreator: () -> Call<T>,
     private val databaseInsertFunction: (T) -> Unit,
     private val databaseRetrievalFunction: () -> LiveData<T>
 ) {
@@ -18,7 +18,7 @@ class GenericRepository<T>(
     }
 
     private fun refresh() {
-        apiCall.clone().enqueue(object : Callback<T> {
+        apiCallCreator().enqueue(object : Callback<T> {
             override fun onResponse(call: Call<T>, response: Response<T>) {
                 if (response.isSuccessful) {
                     thread {

--- a/app/src/main/java/org/hackillinois/android/repository/Repositories.kt
+++ b/app/src/main/java/org/hackillinois/android/repository/Repositories.kt
@@ -7,17 +7,22 @@ import org.hackillinois.android.database.entity.Roles
 import org.hackillinois.android.database.entity.User
 
 val qrRepository: GenericRepository<QR> by lazy {
-    GenericRepository(App.getAPI().qrCode(), App.database.qrDao()::insert, App.database.qrDao()::getQr)
+    GenericRepository(::createQrCodeCall, App.database.qrDao()::insert, App.database.qrDao()::getQr)
 }
 
 val attendeeRepository: GenericRepository<Attendee> by lazy {
-    GenericRepository(App.getAPI().attendee(), App.database.attendeeDao()::insert, App.database.attendeeDao()::getAttendee)
+    GenericRepository(::createAttendeeCall, App.database.attendeeDao()::insert, App.database.attendeeDao()::getAttendee)
 }
 
 val rolesRepository: GenericRepository<Roles> by lazy {
-    GenericRepository(App.getAPI().roles(), App.database.rolesDao()::insert, App.database.rolesDao()::getRoles)
+    GenericRepository(::createRolesCall, App.database.rolesDao()::insert, App.database.rolesDao()::getRoles)
 }
 
 val userRepository: GenericRepository<User> by lazy {
-    GenericRepository(App.getAPI().user(), App.database.userDao()::insert, App.database.userDao()::getUser)
+    GenericRepository(::createUserCall, App.database.userDao()::insert, App.database.userDao()::getUser)
 }
+
+private fun createQrCodeCall() = App.getAPI().qrCode()
+private fun createAttendeeCall() = App.getAPI().attendee()
+private fun createRolesCall() = App.getAPI().roles()
+private fun createUserCall() = App.getAPI().user()

--- a/app/src/main/java/org/hackillinois/android/view/MainActivity.kt
+++ b/app/src/main/java/org/hackillinois/android/view/MainActivity.kt
@@ -167,6 +167,7 @@ class MainActivity : AppCompatActivity() {
 
         thread {
             App.database.clearAllTables()
+            App.getAPI("")
 
             runOnUiThread {
                 val loginIntent = Intent(this, LoginActivity::class.java)


### PR DESCRIPTION
Fixes #99 

Example issue:
Logging out of a staff account and into guest account (in the same app session) still shows staff member's QR code.

There were two issues:
- JWT was not cleared from API singleton object on logout, so incorrect JWT present when logging out and then in during a single app session
- Current API singleton instance captured when passing `apiCall` to a `GenericRepository` (thus holding the old JWT even if it has been cleared on logout)