### PR TITLE
Fixed bug with ongoing/upcoming events text header

### DIFF
--- a/app/src/main/java/org/hackillinois/android/view/home/eventlist/EventsSection.kt
+++ b/app/src/main/java/org/hackillinois/android/view/home/eventlist/EventsSection.kt
@@ -68,6 +68,12 @@ class EventsSection(
         } else {
             holder.itemView.timeText.visibility = View.GONE
         }
+
+        if (eventsList.isNotEmpty()) {
+            holder.itemView.headerText.visibility = View.VISIBLE
+        } else {
+            holder.itemView.headerText.visibility = View.GONE
+        }
     }
 
     fun updateEventsList(newEventsList: List<Event>) {


### PR DESCRIPTION
Bug used to show header texts even when no events were happening/scheduled.