### PR TITLE
Make error message for scanner come from API response

### DIFF
--- a/app/src/main/java/org/hackillinois/android/view/ScannerFragment.kt
+++ b/app/src/main/java/org/hackillinois/android/view/ScannerFragment.kt
@@ -60,9 +60,6 @@ class ScannerFragment : Fragment() {
                 decodeCallback = DecodeCallback {
                     val userId: String = getUserIdFromQrString(it.text)
                     viewModel.checkUserIntoEvent(eventId, userId, view.staffOverrideSwitch.isChecked)
-                    Handler(Looper.getMainLooper()).post {
-                        Snackbar.make(view.rootView, "Please wait", Snackbar.LENGTH_LONG).show()
-                    }
                 }
                 errorCallback = ErrorCallback {
                     Handler(Looper.getMainLooper()).post {
@@ -116,7 +113,7 @@ class ScannerFragment : Fragment() {
                 staffOverrideSwitch.isChecked = false
                 "Success: ${lastScanStatus.userId}"
             }
-            false -> "User not registered, or already scanned in for event."
+            false -> lastScanStatus.userMessage
         }
 
         view?.let {

--- a/app/src/main/java/org/hackillinois/android/viewmodel/ScannerViewModel.kt
+++ b/app/src/main/java/org/hackillinois/android/viewmodel/ScannerViewModel.kt
@@ -50,7 +50,12 @@ class ScannerViewModel : ViewModel() {
                     lastScanStatus.postValue(scanStatus)
                 } else {
                     val error = JSONObject(response.errorBody()?.string())
-                    val errorMessage = error.getString("message")
+                    val errorType = error.getString("type")
+                    val errorMessage = if (errorType == "ATTRIBUTE_MISMATCH_ERROR") {
+                        error.getString("message")
+                    } else {
+                        "Internal API error"
+                    }
                     var scanStatus = ScanStatus(false, "", errorMessage)
                     lastScanStatus.postValue(scanStatus)
                 }
@@ -73,7 +78,12 @@ class ScannerViewModel : ViewModel() {
                     lastScanStatus.postValue(scanStatus)
                 } else {
                     val error = JSONObject(response.errorBody()?.string())
-                    val errorMessage = error.getString("message")
+                    val errorType = error.getString("type")
+                    val errorMessage = if (errorType == "ATTRIBUTE_MISMATCH_ERROR") {
+                        error.getString("message")
+                    } else {
+                        "Internal API error"
+                    }
                     var scanStatus = ScanStatus(false, "", errorMessage)
                     lastScanStatus.postValue(scanStatus)
                 }

--- a/app/src/main/java/org/hackillinois/android/viewmodel/ScannerViewModel.kt
+++ b/app/src/main/java/org/hackillinois/android/viewmodel/ScannerViewModel.kt
@@ -7,6 +7,7 @@ import org.hackillinois.android.model.ScanStatus
 import org.hackillinois.android.model.checkin.CheckIn
 import org.hackillinois.android.model.event.TrackerContainer
 import org.hackillinois.android.model.event.UserEventPair
+import org.json.JSONObject
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -37,7 +38,7 @@ class ScannerViewModel : ViewModel() {
     fun checkInUser(checkIn: CheckIn) {
         App.getAPI().checkInUser(checkIn).enqueue(object : Callback<CheckIn> {
             override fun onFailure(call: Call<CheckIn>, t: Throwable) {
-                var scanStatus = ScanStatus(false, "", "Request could not be made.")
+                var scanStatus = ScanStatus(false, "", "Request could not be made. Please try again.")
                 lastScanStatus.postValue(scanStatus)
             }
 
@@ -48,7 +49,9 @@ class ScannerViewModel : ViewModel() {
                     var scanStatus = ScanStatus(true, userId, "")
                     lastScanStatus.postValue(scanStatus)
                 } else {
-                    var scanStatus = ScanStatus(false, "", "Could not check in user.")
+                    val error = JSONObject(response.errorBody()?.string())
+                    val errorMessage = error.getString("message")
+                    var scanStatus = ScanStatus(false, "", errorMessage)
                     lastScanStatus.postValue(scanStatus)
                 }
             }
@@ -58,7 +61,7 @@ class ScannerViewModel : ViewModel() {
     fun markUserAsAttendingEvent(userEventPair: UserEventPair) {
         App.getAPI().markUserAsAttendingEvent(userEventPair).enqueue(object : Callback<TrackerContainer> {
             override fun onFailure(call: Call<TrackerContainer>, t: Throwable) {
-                var scanStatus = ScanStatus(false, "", "Request could not be made.")
+                var scanStatus = ScanStatus(false, "", "Request could not be made. Please try again.")
                 lastScanStatus.postValue(scanStatus)
             }
 
@@ -69,7 +72,9 @@ class ScannerViewModel : ViewModel() {
                     var scanStatus = ScanStatus(true, userId, "")
                     lastScanStatus.postValue(scanStatus)
                 } else {
-                    var scanStatus = ScanStatus(false, "", "Could not check in user.")
+                    val error = JSONObject(response.errorBody()?.string())
+                    val errorMessage = error.getString("message")
+                    var scanStatus = ScanStatus(false, "", errorMessage)
                     lastScanStatus.postValue(scanStatus)
                 }
             }


### PR DESCRIPTION
Uses API error response for scanning error messages.

Fixes #124 