### PR TITLE
Fix notifications manager

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,7 +67,11 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
     implementation 'io.github.luizgrp.sectionedrecyclerviewadapter:sectionedrecyclerviewadapter:3.1.0'
     implementation 'com.airbnb.android:lottie:3.3.1'
-    implementation 'androidx.fragment:fragment:1.4.1'
+    implementation 'androidx.fragment:fragment-ktx:1.4.1'
+
+    // for targeting API level 31+ notifications
+    implementation 'androidx.work:work-runtime-ktx:2.7.1'
+
 
     // Zoomable images
     implementation 'com.davemorrissey.labs:subsampling-scale-image-view:3.10.0'

--- a/app/src/main/java/org/hackillinois/android/notifications/HackIllinoisNotificationManager.kt
+++ b/app/src/main/java/org/hackillinois/android/notifications/HackIllinoisNotificationManager.kt
@@ -47,7 +47,8 @@ object HackIllinoisNotificationManager {
             putExtra("notification", notification)
             putExtra("notification_id", 1)
         }
-        return PendingIntent.getBroadcast(context, REQUEST_CODE, intent, PendingIntent.FLAG_CANCEL_CURRENT)
+        val flags = PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        return PendingIntent.getBroadcast(context, REQUEST_CODE, intent, flags)
     }
 
     private fun buildEventNotification(context: Context, event: Event): Notification {

--- a/app/src/main/java/org/hackillinois/android/view/schedule/EventsAdapter.kt
+++ b/app/src/main/java/org/hackillinois/android/view/schedule/EventsAdapter.kt
@@ -6,7 +6,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.event_tile.view.*
 import kotlinx.android.synthetic.main.time_list_item.view.*
 import org.hackillinois.android.R

--- a/app/src/main/java/org/hackillinois/android/view/schedule/EventsAdapter.kt
+++ b/app/src/main/java/org/hackillinois/android/view/schedule/EventsAdapter.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.event_tile.view.*
@@ -95,7 +96,8 @@ class EventsAdapter(
 
                 if (button.isSelected) {
                     FavoritesManager.favoriteEvent(context, event)
-                    Snackbar.make(button, R.string.schedule_snackbar_notifications_on, Snackbar.LENGTH_SHORT).show()
+                    val toast = Toast.makeText(context, R.string.schedule_snackbar_notifications_on, Toast.LENGTH_SHORT)
+                    toast.show()
                 } else {
                     FavoritesManager.unfavoriteEvent(context, event)
                 }


### PR DESCRIPTION
When we began targeting API 31, we needed to also say that the notification is immutable in order to process it. This should fix app crash on event favorite