### PR TITLE
Updated auth endpoints and login flow

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ android {
     defaultConfig {
         buildConfigField "String", "API_KEY", "\"localProperties.getProperty('apiKey')\""
         applicationId "org.hackillinois.android"
-        minSdkVersion 22
+        minSdkVersion 23
         targetSdkVersion 31
         versionCode 41
         versionName "3.0.1"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ android {
     defaultConfig {
         buildConfigField "String", "API_KEY", "\"localProperties.getProperty('apiKey')\""
         applicationId "org.hackillinois.android"
-        minSdkVersion 23
+        minSdkVersion 22
         targetSdkVersion 31
         versionCode 41
         versionName "3.0.1"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -61,10 +61,11 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data
-                    android:host="org.hackillinois.android"
-                    android:pathPrefix="/auth"
-                    android:scheme="hackillinois" />
+<!--                <data-->
+<!--                    android:host="org.hackillinois.android"-->
+<!--                    android:pathPrefix="/auth"-->
+<!--                    android:scheme="hackillinois" />-->
+                <data android:scheme="hackillinois" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/org/hackillinois/android/API.kt
+++ b/app/src/main/java/org/hackillinois/android/API.kt
@@ -3,8 +3,6 @@ package org.hackillinois.android
 import okhttp3.ResponseBody
 import org.hackillinois.android.database.entity.*
 import org.hackillinois.android.model.TimesWrapper
-import org.hackillinois.android.model.auth.Code
-import org.hackillinois.android.model.auth.JWT
 import org.hackillinois.android.model.checkin.CheckIn
 import org.hackillinois.android.model.event.EventsList
 import org.hackillinois.android.model.event.TrackerContainer
@@ -21,24 +19,8 @@ import retrofit2.http.*
 interface API {
 
     // AUTH
-
-//    @POST("auth/code/{provider}/")
-//    suspend fun getJWT(
-//        @Path("provider") provider: String,
-//        @Query("redirect_uri") redirect: String,
-//        @Body code: Code,
-//    ): JWT
-
-//    @GET("auth/{provider}/")
-//    suspend fun getJWT(
-//            @Path("provider") provider: String,
-//    ): JWT
-
-    @GET("auth/login/{provider}/")
-    suspend fun getJWT(
-        @Path("provider") provider: String,
-        @Query("device") device: String,
-    ): JWT
+    // note: @GET("auth/login/{provider}/") is not part of this file because the URL
+    // is directly accessed in the LoginActivity.kt file to get to the OAuth page
 
     @GET("auth/roles/")
     suspend fun roles(): Roles

--- a/app/src/main/java/org/hackillinois/android/API.kt
+++ b/app/src/main/java/org/hackillinois/android/API.kt
@@ -22,11 +22,16 @@ interface API {
 
     // AUTH
 
-    @POST("auth/code/{provider}/")
+//    @POST("auth/code/{provider}/")
+//    suspend fun getJWT(
+//        @Path("provider") provider: String,
+//        @Query("redirect_uri") redirect: String,
+//        @Body code: Code,
+//    ): JWT
+
+    @GET("auth/{provider}/")
     suspend fun getJWT(
         @Path("provider") provider: String,
-        @Query("redirect_uri") redirect: String,
-        @Body code: Code,
     ): JWT
 
     @GET("auth/roles/")

--- a/app/src/main/java/org/hackillinois/android/API.kt
+++ b/app/src/main/java/org/hackillinois/android/API.kt
@@ -26,7 +26,7 @@ interface API {
     suspend fun getJWT(
         @Path("provider") provider: String,
         @Query("redirect_uri") redirect: String,
-        @Body code: Code
+        @Body code: Code,
     ): JWT
 
     @GET("auth/roles/")
@@ -106,6 +106,6 @@ interface API {
     suspend fun leaderboard(): LeaderboardList
 
     companion object {
-        val BASE_URL = "https://api.hackillinois.org/"
+        val BASE_URL = "https://adonix.hackillinois.org/"
     }
 }

--- a/app/src/main/java/org/hackillinois/android/API.kt
+++ b/app/src/main/java/org/hackillinois/android/API.kt
@@ -29,9 +29,15 @@ interface API {
 //        @Body code: Code,
 //    ): JWT
 
-    @GET("auth/{provider}/")
+//    @GET("auth/{provider}/")
+//    suspend fun getJWT(
+//            @Path("provider") provider: String,
+//    ): JWT
+
+    @GET("auth/login/{provider}/")
     suspend fun getJWT(
         @Path("provider") provider: String,
+        @Query("device") device: String,
     ): JWT
 
     @GET("auth/roles/")

--- a/app/src/main/java/org/hackillinois/android/model/auth/Code.kt
+++ b/app/src/main/java/org/hackillinois/android/model/auth/Code.kt
@@ -1,3 +1,0 @@
-package org.hackillinois.android.model.auth
-
-data class Code(val code: String)

--- a/app/src/main/java/org/hackillinois/android/view/LoginActivity.kt
+++ b/app/src/main/java/org/hackillinois/android/view/LoginActivity.kt
@@ -19,14 +19,13 @@ import org.hackillinois.android.App
 import org.hackillinois.android.R
 import org.hackillinois.android.common.JWTUtilities
 import org.hackillinois.android.database.entity.Roles
-import org.hackillinois.android.model.auth.Code
 import org.hackillinois.android.model.auth.JWT
 import retrofit2.HttpException
 import java.net.SocketTimeoutException
 
 class LoginActivity : AppCompatActivity() {
     private val redirectUri: String = "https://hackillinois.org/auth/?isAndroid=1"
-    private val authUriTemplate: String = "https://api.hackillinois.org/auth/%s/?redirect_uri=%s"
+    private val authUriTemplate: String = "https://adonix.hackillinois.org/auth/%s/?redirect_uri=%s"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -53,19 +52,21 @@ class LoginActivity : AppCompatActivity() {
         val intent = intent ?: return
         intent.action ?: return
 
-        val uri = intent.data ?: return
+//        val uri = intent.data ?: return
+//
+//        val code = uri.getQueryParameter("code") ?: return
 
-        val code = uri.getQueryParameter("code") ?: return
-
-        finishLogin(code)
+//        finishLogin(code)
+        finishLogin()
     }
 
-    private fun finishLogin(code: String) {
-        // TODO needs review
+//    private fun finishLogin(code: String) {
+    private fun finishLogin() {
         var api = App.getAPI()
         GlobalScope.launch {
             try {
-                val jwt: JWT = api.getJWT(getOAuthProvider(), redirectUri, Code(code))
+//                val jwt: JWT = api.getJWT(getOAuthProvider(), redirectUri, Code(code))
+                val jwt: JWT = api.getJWT(getOAuthProvider())
                 api = App.getAPI(jwt.token)
                 withContext(Dispatchers.IO) {
                     try {
@@ -123,7 +124,7 @@ class LoginActivity : AppCompatActivity() {
             findViewById(android.R.id.content),
             "You must have a valid staff account" +
                 " to log in.",
-            Snackbar.LENGTH_SHORT
+            Snackbar.LENGTH_SHORT,
         ).show()
     }
 

--- a/app/src/main/java/org/hackillinois/android/view/LoginActivity.kt
+++ b/app/src/main/java/org/hackillinois/android/view/LoginActivity.kt
@@ -24,6 +24,7 @@ import retrofit2.HttpException
 import java.net.SocketTimeoutException
 
 class LoginActivity : AppCompatActivity() {
+    // https://hackillinois.org/auth?redirect_uri=https://hackillinois.org/auth/?isAndroid=1
     private val redirectUri: String = "https://hackillinois.org/auth/?isAndroid=1"
     private val authUriTemplate: String = "https://adonix.hackillinois.org/auth/%s/?redirect_uri=%s"
 
@@ -52,9 +53,9 @@ class LoginActivity : AppCompatActivity() {
         val intent = intent ?: return
         intent.action ?: return
 
-//        val uri = intent.data ?: return
+        val uri = intent.data ?: return
 //
-//        val code = uri.getQueryParameter("code") ?: return
+        val code = uri.getQueryParameter("code") ?: return
 
 //        finishLogin(code)
         finishLogin()
@@ -62,30 +63,30 @@ class LoginActivity : AppCompatActivity() {
 
 //    private fun finishLogin(code: String) {
     private fun finishLogin() {
-        var api = App.getAPI()
-        GlobalScope.launch {
-            try {
+//        var api = App.getAPI()
+//        GlobalScope.launch {
+//            try {
 //                val jwt: JWT = api.getJWT(getOAuthProvider(), redirectUri, Code(code))
-                val jwt: JWT = api.getJWT(getOAuthProvider())
-                api = App.getAPI(jwt.token)
-                withContext(Dispatchers.IO) {
-                    try {
-                        // TODO httpException 405
-                        // api.updateNotificationTopics()
-                    } catch (e: SocketTimeoutException) {
-                        Log.e("LoginActivity", "Notifications update timed out!")
-                    }
-                }
-
-                if (getOAuthProvider() == "google") {
-                    verifyRole(api, jwt.token, "Staff")
-                } else {
-                    verifyRole(api, jwt.token, "Attendee")
-                }
-            } catch (e: Exception) {
-                showFailedToLoginStaff()
-            }
-        }
+//                val jwt: JWT = api.getJWT(getOAuthProvider(), "android")
+//                api = App.getAPI(jwt.token)
+//                withContext(Dispatchers.IO) {
+//                    try {
+//                        // TODO httpException 405
+//                        // api.updateNotificationTopics()
+//                    } catch (e: SocketTimeoutException) {
+//                        Log.e("LoginActivity", "Notifications update timed out!")
+//                    }
+//                }
+//
+//                if (getOAuthProvider() == "google") {
+//                    verifyRole(api, jwt.token, "Staff")
+//                } else {
+//                    verifyRole(api, jwt.token, "Attendee")
+//                }
+//            } catch (e: Exception) {
+//                showFailedToLoginStaff()
+//            }
+//        }
     }
 
     private fun verifyRole(api: API, jwt: String, role: String) {
@@ -138,11 +139,42 @@ class LoginActivity : AppCompatActivity() {
         finish()
     }
 
+    private fun tryLogin() {
+        var api = App.getAPI()
+        GlobalScope.launch {
+            try {
+//                val jwt: JWT = api.getJWT(getOAuthProvider(), redirectUri, Code(code))
+                Log.d("LOGIN", "BEFORE API CALL")
+                Log.d("LOGIN", "${getOAuthProvider()}")
+                val jwt: JWT = api.getJWT(getOAuthProvider(), "android")
+                Log.d("LOGIN", "AFTER API CALL")
+                api = App.getAPI(jwt.token)
+                withContext(Dispatchers.IO) {
+                    try {
+                        // TODO httpException 405
+                        // api.updateNotificationTopics()
+                    } catch (e: SocketTimeoutException) {
+                        Log.e("LoginActivity", "Notifications update timed out!")
+                    }
+                }
+
+                if (getOAuthProvider() == "google") {
+                    verifyRole(api, jwt.token, "Staff")
+                } else {
+                    verifyRole(api, jwt.token, "Attendee")
+                }
+            } catch (e: Exception) {
+                showFailedToLoginStaff()
+            }
+        }
+    }
+
     private fun redirectToOAuthProvider(provider: String) {
-        val intent = Intent(Intent.ACTION_VIEW)
-        intent.data = Uri.parse(authUriTemplate.format(provider, redirectUri))
+//        val intent = Intent(Intent.ACTION_VIEW)
+//        intent.data = Uri.parse(authUriTemplate.format(provider, redirectUri))
         setOAuthProvider(provider)
-        startActivity(intent)
+//        startActivity(intent)
+        tryLogin()
     }
 
     private fun setOAuthProvider(provider: String) {

--- a/app/src/main/java/org/hackillinois/android/view/LoginActivity.kt
+++ b/app/src/main/java/org/hackillinois/android/view/LoginActivity.kt
@@ -90,6 +90,7 @@ class LoginActivity : AppCompatActivity() {
                 }
             } catch (e: Exception) {
                 showFailedToLoginStaff()
+                showFailedToLogin(e.message)
             }
         }
     }
@@ -121,7 +122,24 @@ class LoginActivity : AppCompatActivity() {
                         showFailedToLoginStaff()
                     }
                 }
+                showFailedToLogin(e.message)
             }
+        }
+    }
+
+    private fun showFailedToLogin(message: String?) {
+        if (message != null) {
+            Snackbar.make(
+                findViewById(android.R.id.content),
+                message.toString(),
+                Snackbar.LENGTH_SHORT,
+            ).show()
+        } else {
+            Snackbar.make(
+                findViewById(android.R.id.content),
+                "Failed to login. Please try again.",
+                Snackbar.LENGTH_SHORT,
+            ).show()
         }
     }
 

--- a/app/src/main/java/org/hackillinois/android/view/LoginActivity.kt
+++ b/app/src/main/java/org/hackillinois/android/view/LoginActivity.kt
@@ -20,7 +20,6 @@ import org.hackillinois.android.R
 import org.hackillinois.android.common.JWTUtilities
 import org.hackillinois.android.database.entity.Roles
 import org.hackillinois.android.model.auth.JWT
-import retrofit2.HttpException
 import java.net.SocketTimeoutException
 
 class LoginActivity : AppCompatActivity() {

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -19,11 +19,11 @@
         app:layout_constraintTop_toTopOf="parent"
         android:src="@drawable/home_bg"/>
 
-    <ImageView
+    <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/countdownBannerImageView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:src="@drawable/countdown_text_banner"
+        app:srcCompat="@drawable/countdown_text_banner"
         android:scaleX="1.2"
         android:scaleY="1.2"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
* Now uses the `auth/login/PROVIDER/` endpoint (initialize Intent with url)
* No longer exchange a code for the token, get token from uri query parameter upon returning to device
* Added documentation (comments) to clarify the entire login flow