### PR TITLE
Swipe down refresh animation

### DIFF
--- a/app/src/main/java/org/hackillinois/android/view/leaderboard/LeaderboardFragment.kt
+++ b/app/src/main/java/org/hackillinois/android/view/leaderboard/LeaderboardFragment.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.dinuscxj.refresh.RecyclerRefreshLayout
 import kotlinx.android.synthetic.main.fragment_leaderboard.view.*
 import org.hackillinois.android.R
 import org.hackillinois.android.database.entity.Leaderboard
@@ -31,6 +32,7 @@ class LeaderboardFragment : Fragment() {
     private lateinit var recyclerView: RecyclerView
     private lateinit var mLayoutManager: LinearLayoutManager
     private lateinit var mAdapter: LeaderboardAdapter
+    private lateinit var refreshLayout: RecyclerRefreshLayout
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -45,6 +47,8 @@ class LeaderboardFragment : Fragment() {
     ): View? {
         val view = inflater.inflate(R.layout.fragment_leaderboard, container, false)
 
+        refreshLayout = view.findViewById(R.id.refresh_layout)
+
         mAdapter = LeaderboardAdapter(leaderboard)
 
         recyclerView = view.recyclerview_leaderboard.apply {
@@ -52,6 +56,12 @@ class LeaderboardFragment : Fragment() {
             this.layoutManager = mLayoutManager
             this.adapter = mAdapter
             addItemDecorationWithoutLastItem()
+        }
+
+        refreshLayout.setOnRefreshListener {
+            // code to refresh list
+            viewModel.leaderboardRepository.fetchLeaderboard()
+            refreshLayout.setRefreshing(false)
         }
 
         viewModel.leaderboardLiveData.observe(

--- a/app/src/main/java/org/hackillinois/android/viewmodel/LeaderboardViewModel.kt
+++ b/app/src/main/java/org/hackillinois/android/viewmodel/LeaderboardViewModel.kt
@@ -6,7 +6,7 @@ import org.hackillinois.android.database.entity.Leaderboard
 import org.hackillinois.android.repository.LeaderboardRepository
 
 class LeaderboardViewModel : ViewModel() {
-    private val leaderboardRepository = LeaderboardRepository.instance
+    val leaderboardRepository = LeaderboardRepository.instance
 
     lateinit var leaderboardLiveData: LiveData<List<Leaderboard>>
 

--- a/app/src/main/res/layout/fragment_leaderboard.xml
+++ b/app/src/main/res/layout/fragment_leaderboard.xml
@@ -35,20 +35,23 @@
         android:textColor="@color/white"
         android:text="@string/leaderboard"
  />
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recyclerview_leaderboard"
+    <com.dinuscxj.refresh.RecyclerRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/refresh_layout"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_marginTop="24dp"
-        android:layout_marginBottom="50dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/title_textview_leaderboard"
-        app:layout_constraintBottom_toBottomOf="parent"
-        android:paddingEnd="31dp"
-        android:paddingStart="31dp"
-        android:paddingBottom="30dp"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
-
+        android:layout_height="match_parent">
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerview_leaderboard"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="24dp"
+            android:layout_marginBottom="50dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/title_textview_leaderboard"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:paddingEnd="31dp"
+            android:paddingStart="31dp"
+            android:paddingBottom="30dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+    </com.dinuscxj.refresh.RecyclerRefreshLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
- no gradle files :)

Using RecyclerRefreshLayout:
https://github.com/dinuscxj/RecyclerRefreshLayout

Reference:
https://guides.codepath.com/android/implementing-pull-to-refresh-guide

Notes from last PR:
- the RecyclerRefreshLayout needs to be constrained to the bottom of the leaderboard title since right now it's on top of it (maybe wrap in a constraint layout? or is there a better solution)
- can we use a custom animation with this framework? (i.e. like the custom ferris wheel animation Design made last year)