### PR TITLE
Updated user unfollow and itemshop buying endpoints

### DIFF
--- a/app/src/main/java/org/hackillinois/android/API.kt
+++ b/app/src/main/java/org/hackillinois/android/API.kt
@@ -67,7 +67,7 @@ interface API {
     suspend fun shop(): List<ShopItem>
 
     @POST("shop/item/buy/")
-    suspend fun buyShopItem(@Body body: ItemInstance): List<ShopItem>
+    suspend fun buyShopItem(@Body body: ItemInstance): ShopItem
 
     // STAFF
 

--- a/app/src/main/java/org/hackillinois/android/API.kt
+++ b/app/src/main/java/org/hackillinois/android/API.kt
@@ -11,7 +11,6 @@ import org.hackillinois.android.model.scanner.MentorId
 import org.hackillinois.android.model.scanner.Points
 import org.hackillinois.android.model.scanner.UserEventPair
 import org.hackillinois.android.model.shop.ItemInstance
-import org.hackillinois.android.model.shop.ItemName
 import org.hackillinois.android.model.user.FavoritesResponse
 import org.hackillinois.android.model.version.Version
 import org.hackillinois.android.notifications.DeviceToken

--- a/app/src/main/java/org/hackillinois/android/API.kt
+++ b/app/src/main/java/org/hackillinois/android/API.kt
@@ -68,7 +68,7 @@ interface API {
     suspend fun shop(): List<ShopItem>
 
     @POST("shop/item/buy/")
-    suspend fun buyShopItem(@Body body: ItemInstance): ItemName
+    suspend fun buyShopItem(@Body body: ItemInstance): List<ShopItem>
 
     // STAFF
 
@@ -89,8 +89,8 @@ interface API {
     @PUT("user/follow/")
     fun followEvent(@Body eventId: EventId): Call<FavoritesResponse>
 
-    @PUT("user/unfollow/")
-    fun unfollowEvent(@Body eventId: EventId): Call<FavoritesResponse>
+    @DELETE("user/unfollow/{eventId}")
+    fun unfollowEvent(@Path("eventId") eventId: EventId): Call<FavoritesResponse>
 
     @GET("user/v2-qr/")
     suspend fun qrCode(): QR

--- a/app/src/main/java/org/hackillinois/android/viewmodel/ScannerViewModel.kt
+++ b/app/src/main/java/org/hackillinois/android/viewmodel/ScannerViewModel.kt
@@ -12,6 +12,7 @@ import org.hackillinois.android.model.scanner.ScanStatus
 import org.hackillinois.android.model.scanner.UserEventPair
 import org.hackillinois.android.model.shop.ItemInstance
 import org.hackillinois.android.repository.rolesRepository
+import
 import org.json.JSONObject
 import retrofit2.HttpException
 import kotlin.Exception
@@ -122,8 +123,8 @@ class ScannerViewModel : ViewModel() {
         viewModelScope.launch {
             try {
                 Log.d("ITEMINSTANCE", body.toString())
-                val itemName = App.getAPI().buyShopItem(body)
-                val message = "You have successfully redeemed ${itemName.itemName} from the Point Shop!"
+                val item = App.getAPI().buyShopItem(body)
+                val message = "You have successfully redeemed ${item.name} from the Point Shop!"
                 val scanStatus = ScanStatus(message, true)
                 lastScanStatus.postValue(scanStatus)
             } catch (e: Exception) {

--- a/app/src/main/java/org/hackillinois/android/viewmodel/ScannerViewModel.kt
+++ b/app/src/main/java/org/hackillinois/android/viewmodel/ScannerViewModel.kt
@@ -12,7 +12,6 @@ import org.hackillinois.android.model.scanner.ScanStatus
 import org.hackillinois.android.model.scanner.UserEventPair
 import org.hackillinois.android.model.shop.ItemInstance
 import org.hackillinois.android.repository.rolesRepository
-import
 import org.json.JSONObject
 import retrofit2.HttpException
 import kotlin.Exception


### PR DESCRIPTION
Updated the following endpoints:

- `PUT /user/unfollow/` with `{ eventId: "event1"}` to `DELETE /user/unfollow/event1/`
    - Passes event id to unfollow as path parameter instead of as the body and changes method to `DELETE`

- `POST /shop/item/buy/` returns `{ name: "Jacket", ..all additional item properties }` instead of `{ itemName: "Jacket" }`
    - Returns the full information of the item bought instead of just `itemName`, which changes item name to be under `name` instead of `itemName`